### PR TITLE
Fix simplex pivot column selection

### DIFF
--- a/core/simplex_solver.py
+++ b/core/simplex_solver.py
@@ -209,10 +209,13 @@ class SimplexSolver:
     @staticmethod
     def _pivot_col(T):
         """Encontra a coluna com o custo reduzido mais negativo."""
-        negative_costs = T[0, :-1] < -1e-8
-        if not np.any(negative_costs):
+        costs = T[0, :-1]
+        negative_idx = np.where(costs < -1e-8)[0]
+        if negative_idx.size == 0:
             return -1
-        return int(np.where(negative_costs)[0][0])
+        # Escolhe o menor custo reduzido dentre os negativos
+        min_idx = negative_idx[np.argmin(costs[negative_idx])]
+        return int(min_idx)
 
     @staticmethod
     def _pivot_row(T, pc):

--- a/tests/test_pivot_col.py
+++ b/tests/test_pivot_col.py
@@ -1,0 +1,9 @@
+import numpy as np
+from core.simplex_solver import SimplexSolver
+
+def test_pivot_col_selects_most_negative():
+    # Costs -1 and -3, last column is RHS (ignored)
+    tableau = np.array([[-1.0, -3.0, 0.0]])
+    col = SimplexSolver._pivot_col(tableau)
+    assert col == 1
+


### PR DESCRIPTION
## Summary
- Ensure Simplex solver chooses the column with the most negative reduced cost when selecting the pivot column
- Add regression test for pivot column selection

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688fce6ca0ec832a928b6703eda04b01